### PR TITLE
Gallery 1

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -50,7 +50,7 @@
                     <h1>WELCOME</h1>   
                 </div>
             </div>
-            <div id="GalleryWrapper" class="tabContent">
+            <div id="galleryWrapper" title="galleryTab" class="tabContent">
             </div>
         </div>
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -52,23 +52,91 @@
             </div>
             <div id="galleryWrapper" title="galleryTab" class="tabContent">
                 <div id="galleryGrid">
-                    <div class="grid-item" style="background-image: url('images/gallery/home-1.jpg')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/trouble-1.jpg')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/edi-11.jpg')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/swiss-2.JPG')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/edi-3.jpg')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/swiss-1.JPG')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/edi-4.jpg')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/shadow-1.jpg')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/edi-5.jpg')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/Nice-1.JPG')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/edi-6.jpg')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/Niagara-1.jpg')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/edi-7.jpg')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/home-2.jpg')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/edi-9.jpg')"></div> 
-                    <div class="grid-item" style="background-image: url('images/gallery/Monaco-1.JPG')"></div>
-                    <div class="grid-item" style="background-image: url('images/gallery/swiss-4.JPG')"></div>
+                    <div class="gridItem" style="background-image: url('images/gallery/home-1.jpg')">
+                        <div class="caption"> 
+                            <p> My favourite photo of lake Ontario taken near my home </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/trouble-1.jpg')">
+                        <div class="caption">
+                            <p> This is one of my cats, her name is Trouble </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/edi-11.jpg')">
+                        <div class="caption">
+                            <p> The view of Edinburgh from the Salisbury Crags </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/swiss-2.JPG')">
+                        <div class="caption">
+                            <p> A birds-eye view of Wengen from Mänlichen, Switzerland </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/edi-3.jpg')">
+                        <div class="caption">
+                            <p> Edinburgh from near the top of Arthur's seat </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/swiss-1.JPG')">
+                        <div class="caption">
+                            <p> Near Lauterbrunnen, Switzerland </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/edi-4.jpg')">
+                        <div class="caption">
+                            <p> Climate Strike in the Meadows, Edinburgh </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/shadow-1.jpg')">
+                        <div class="caption">
+                            <p> This is my other cat named Shadow </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/edi-5.jpg')">
+                        <div class="caption">
+                            <p> Princes street at night in Edinburgh </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/Nice-1.JPG')">
+                        <div class="caption">
+                            <p> Beautiful view of Nice from Parc du Mont Boron </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/edi-6.jpg')">
+                        <div class="caption">
+                            <p> Edinburgh or Hogsmeade? </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/Niagara-1.jpg')">
+                        <div class="caption">
+                            <p> The Canadian side of Niagara Falls is superior </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/edi-7.jpg')">
+                        <div class="caption">
+                            <p> My favourite place in Edinburgh is Holyrood Park </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/home-2.jpg')">
+                        <div class="caption">
+                            <p> One of my favourite hiking trails back home </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/edi-9.jpg')">
+                        <div class="caption">
+                            <p> Nice view from Appleton Tower </p>
+                        </div>
+                    </div> 
+                    <div class="gridItem" style="background-image: url('images/gallery/Monaco-1.JPG')">
+                        <div class="caption">
+                            <p> It's ridiculous how small Monaco is </p>
+                        </div>
+                    </div>
+                    <div class="gridItem" style="background-image: url('images/gallery/swiss-4.JPG')">
+                        <div class="caption">
+                            <p> Original windows background material from Lauterbrunnen </p>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -47,10 +47,19 @@
                 </div>
 
                 <div title="welcomeTab"   class="tabContent tabText tabSelected"> 
-                    <h1>WELCOME</h1>   
+                    <h1>WELCOME</h1>  
                 </div>
             </div>
             <div id="galleryWrapper" title="galleryTab" class="tabContent">
+                <div id="galleryGrid">
+                    <div class="grid-item"></div>
+                    <div class="grid-item"></div>
+                    <div class="grid-item"></div>
+                    <div class="grid-item"></div>
+                    <div class="grid-item"></div>
+                    <div class="grid-item"></div>
+                    <div class="grid-item"></div>
+                </div>
             </div>
         </div>
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -34,10 +34,6 @@
                     <div title="welcomeTab"   style="background-image: url('images/Alice.jpg')"     class="tabContent tabPicture tabSelected"> </div>
             </div>
             <div id="textWrapper">
-                <div title="galleryTab"   class="tabContent tabText">
-                    <h1>GALLERY</h1>
-                </div>
-
                 <div title="projectsTab"  class="tabContent tabText">             
                     <h1>PROJECTS</h1>  
                 </div>
@@ -53,6 +49,8 @@
                 <div title="welcomeTab"   class="tabContent tabText tabSelected"> 
                     <h1>WELCOME</h1>   
                 </div>
+            </div>
+            <div id="GalleryWrapper" class="tabContent">
             </div>
         </div>
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -52,13 +52,23 @@
             </div>
             <div id="galleryWrapper" title="galleryTab" class="tabContent">
                 <div id="galleryGrid">
-                    <div class="grid-item"></div>
-                    <div class="grid-item"></div>
-                    <div class="grid-item"></div>
-                    <div class="grid-item"></div>
-                    <div class="grid-item"></div>
-                    <div class="grid-item"></div>
-                    <div class="grid-item"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/home-1.jpg')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/trouble-1.jpg')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/edi-11.jpg')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/swiss-2.JPG')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/edi-3.jpg')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/swiss-1.JPG')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/edi-4.jpg')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/shadow-1.jpg')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/edi-5.jpg')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/Nice-1.JPG')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/edi-6.jpg')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/Niagara-1.jpg')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/edi-7.jpg')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/home-2.jpg')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/edi-9.jpg')"></div> 
+                    <div class="grid-item" style="background-image: url('images/gallery/Monaco-1.JPG')"></div>
+                    <div class="grid-item" style="background-image: url('images/gallery/swiss-4.JPG')"></div>
                 </div>
             </div>
         </div>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TAB FEATURES
+
 function toggleClass(obj, className, toAdd) {
     toAdd? obj.classList.add(className): obj.classList.remove(className);
 }
@@ -73,9 +75,46 @@ function setTabEvents(tabs) {
     }
 } // setTabEvents
 
+
+// GALLERY FEATURES
+
+function getCaption(galleryPic) {
+    return galleryPic.childNodes[1];
+}
+
+function fadeAnimation(caption, fadeIn) {
+    if (fadeIn) {
+        caption.style["animation-name"] = fadeInName;
+    }
+    else {
+        caption.style["animation-name"] = fadeOutName;
+    }
+}
+
+function fadeCaption(pic, fadeIn) {
+    var caption = getCaption(pic);
+    fadeAnimation(caption, fadeIn);
+}
+
+function setGalleryEvents(galleryPics) {
+    var pic;
+    for (var i = 0; i < galleryPics.length; i++) {
+        pic = galleryPics[i];
+        pic.addEventListener("mouseover", function() {
+            fadeCaption(this, true);
+        });
+        pic.addEventListener("mouseout", function() {
+            fadeCaption(this, false);
+        });
+    }
+}
+
+
 function setUp() {
     var tabs = document.getElementsByClassName(tabClass);
     setTabEvents(tabs);
+    var galleryPics = document.getElementsByClassName(galleryPicClass);
+    setGalleryEvents(galleryPics);
 }
 
 const tabHoverClass = "tabHover";
@@ -83,3 +122,7 @@ const tabSelectedClass = "tabSelected";
 const tabClass = "tab";
 const tabContentClass = "tabContent";
 const galleryTitle = "galleryTab";
+const galleryPicClass = "gridItem"
+const fadeInName = "fadeIn";
+const fadeOutName = "fadeOut";
+const captionClass = "caption";

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -37,13 +37,11 @@ function prevSelectedTab() {
 }
 
 function toggleGallerySelection(showGallery) {
-    console.log("here");
     var textWrapper = document.getElementById("textWrapper");
     var pictureWrapper = document.getElementById("pictureWrapper");
     if (showGallery) {
         textWrapper.style.display = "none";
         pictureWrapper.style.display = "none";
-
     }
     else {
         textWrapper.style.display = "flex";

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -36,6 +36,20 @@ function prevSelectedTab() {
     return document.getElementsByClassName(tabClass+" "+tabSelectedClass)[0];
 }
 
+function toggleGallerySelection(showGallery) {
+    console.log("here");
+    var textWrapper = document.getElementById("textWrapper");
+    var pictureWrapper = document.getElementById("pictureWrapper");
+    if (showGallery) {
+        textWrapper.style.display = "none";
+        pictureWrapper.style.display = "none";
+
+    }
+    else {
+        textWrapper.style.display = "flex";
+        pictureWrapper.style.display = "flex";    
+    }
+}
 
 function setTabEvents(tabs) {
     var tab;
@@ -50,13 +64,19 @@ function setTabEvents(tabs) {
         });
 
         tab.addEventListener("click", function() {
+            if (prevSelectedTab().getAttribute("title") === galleryTitle) {
+                toggleGallerySelection(false);
+            }
+            else if (this.getAttribute("title") === galleryTitle) {
+                toggleGallerySelection(true);
+            }
             switchTabSelection(prevSelectedTab(), this);
         });
     }
 } // setTabEvents
 
 function setUp() {
-    var tabs = document.getElementsByClassName("tab");
+    var tabs = document.getElementsByClassName(tabClass);
     setTabEvents(tabs);
 }
 
@@ -64,3 +84,4 @@ const tabHoverClass = "tabHover";
 const tabSelectedClass = "tabSelected";
 const tabClass = "tab";
 const tabContentClass = "tabContent";
+const galleryTitle = "galleryTab";

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -76,45 +76,9 @@ function setTabEvents(tabs) {
 } // setTabEvents
 
 
-// GALLERY FEATURES
-
-function getCaption(galleryPic) {
-    return galleryPic.childNodes[1];
-}
-
-function fadeAnimation(caption, fadeIn) {
-    if (fadeIn) {
-        caption.style["animation-name"] = fadeInName;
-    }
-    else {
-        caption.style["animation-name"] = fadeOutName;
-    }
-}
-
-function fadeCaption(pic, fadeIn) {
-    var caption = getCaption(pic);
-    fadeAnimation(caption, fadeIn);
-}
-
-function setGalleryEvents(galleryPics) {
-    var pic;
-    for (var i = 0; i < galleryPics.length; i++) {
-        pic = galleryPics[i];
-        pic.addEventListener("mouseover", function() {
-            fadeCaption(this, true);
-        });
-        pic.addEventListener("mouseout", function() {
-            fadeCaption(this, false);
-        });
-    }
-}
-
-
 function setUp() {
     var tabs = document.getElementsByClassName(tabClass);
     setTabEvents(tabs);
-    var galleryPics = document.getElementsByClassName(galleryPicClass);
-    setGalleryEvents(galleryPics);
 }
 
 const tabHoverClass = "tabHover";
@@ -122,7 +86,3 @@ const tabSelectedClass = "tabSelected";
 const tabClass = "tab";
 const tabContentClass = "tabContent";
 const galleryTitle = "galleryTab";
-const galleryPicClass = "gridItem"
-const fadeInName = "fadeIn";
-const fadeOutName = "fadeOut";
-const captionClass = "caption";

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -130,10 +130,10 @@ html, body {
 /* GALLERY PROPERTIES */
 
 #galleryWrapper {
-    margin: 40px;
-    width: 96%;
+    margin: 20px;
+    width: calc(100% - 40px);
     overflow-y: auto;
-    max-height: calc(100% - 40px);
+    max-height: calc(100% - 80px);
 }
 
 #galleryGrid {
@@ -142,8 +142,10 @@ html, body {
 }
 
 .grid-item {
-    border: 1px solid black;
-    height: 400px;
+    height: 500px;
     margin: 10px;
     background-size: cover;
+    background-position-y: center;
+    box-shadow: 10px 10px 10px -8px;
+    border-radius: 20px;
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -152,39 +152,21 @@ html, body {
     align-items: flex-end;
 }
 
-@keyframes fadeIn {
-    from {
-        background: transparent;
-        color: transparent;
-    }
-    to {
-        background: rgba(217, 218, 219, 0.8);
-        color: black;
-    }
-}
-
-@keyframes fadeOut {
-    from {
-        background: rgba(217, 218, 219, 0.8);
-        color: black;
-
-    }
-    to {
-        background: transparent;
-        color: transparent;
-    }
+.gridItem:hover .caption {
+    background-color: rgba(217, 218, 219, 0.8);
+    color: rgba(0, 0, 0, 1);
 }
 
 .caption {
     width: 100%;
     height: 20%;
     border-radius: 0 0 20px 20px;
-    animation-duration: 0.5s;
-    animation-fill-mode: both;
     text-align: center;
     font-size: 20px;
-    color: transparent;
     display: flex;
     justify-content: center;
     align-items: center;
+    transition: background-color 0.5s, color 0.5s;
+    background-color: rgba(217, 218, 219, 0);
+    color: rgba(0, 0, 0, 0);
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -4,6 +4,7 @@ html, body {
     height: 100%;
     margin: 0;
     background-color: azure;
+    overflow: hidden;
 }
 
 #content {
@@ -74,6 +75,7 @@ html, body {
 
 #tabContent {
     height: 72%;
+    width: calc(100% - 36px);
     background-color: rgb(255, 212, 171);
     border-radius: 10px 0px 10px 10px;
     margin: 18px;
@@ -93,6 +95,7 @@ html, body {
 #textWrapper {
     display: flex;
     float:left;
+    overflow-y: auto;
     width: 60%;
     height: 100%;
     padding-top: 10px
@@ -127,7 +130,20 @@ html, body {
 /* GALLERY PROPERTIES */
 
 #galleryWrapper {
-    width: 100%;
-    height: 100%;
-    overflow: scroll;
+    margin: 40px;
+    width: 96%;
+    overflow-y: auto;
+    max-height: calc(100% - 40px);
+}
+
+#galleryGrid {
+    display: grid;
+    grid-template-columns: auto auto auto;
+}
+
+.grid-item {
+    border: 1px solid black;
+    height: 400px;
+    margin: 10px;
+    background-size: cover;
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -123,3 +123,11 @@ html, body {
 .tabText h1 {
     text-align: center;
 }
+
+/* GALLERY PROPERTIES */
+
+#galleryWrapper {
+    width: 100%;
+    height: 100%;
+    overflow: scroll;
+}

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -138,14 +138,53 @@ html, body {
 
 #galleryGrid {
     display: grid;
-    grid-template-columns: auto auto auto;
+    grid-template-columns: 33% 33% 33%;
 }
 
-.grid-item {
+.gridItem {
     height: 500px;
     margin: 10px;
     background-size: cover;
     background-position-y: center;
     box-shadow: 10px 10px 10px -8px;
     border-radius: 20px;
+    display: flex;
+    align-items: flex-end;
+}
+
+@keyframes fadeIn {
+    from {
+        background: transparent;
+        color: transparent;
+    }
+    to {
+        background: rgba(217, 218, 219, 0.8);
+        color: black;
+    }
+}
+
+@keyframes fadeOut {
+    from {
+        background: rgba(217, 218, 219, 0.8);
+        color: black;
+
+    }
+    to {
+        background: transparent;
+        color: transparent;
+    }
+}
+
+.caption {
+    width: 100%;
+    height: 20%;
+    border-radius: 0 0 20px 20px;
+    animation-duration: 0.5s;
+    animation-fill-mode: both;
+    text-align: center;
+    font-size: 20px;
+    color: transparent;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }


### PR DESCRIPTION
Finish gallery tab of Portfolio with photos and captions with fade-in and fade-out transitions.

Since the photo gallery will not include text content, remove the original photo and text wrappers for the gallery tab and replace them with a single divider that will replace both of them and change the "click" event listener for the gallery tab to reflect this change in layout when clicking to and from the gallery tab.

To contain the images in the photo gallery, make individual wrappers for each image in the gallery so that all images have the same dimensions and consistent styling. Position and size the photos so that different window sizes will dynamically resize the images.

Add captions to each photo by adding a divider within each gallery image container. Add event listeners for the image containers such that hovering over and off an image in the gallery will trigger the caption to fade in and fade out respectively.