### PR TITLE
Test driven development

### DIFF
--- a/walkthroughs/week-5-tdd/intro/src/main/java/com/google/sps/Greeter.java
+++ b/walkthroughs/week-5-tdd/intro/src/main/java/com/google/sps/Greeter.java
@@ -22,6 +22,6 @@ public class Greeter {
    * Returns a greeting for the given name.
    */
   public String greet(String name) {
-    return "Hello " + name;
+    return "Hello " + String.join("", name.trim().split("\\W+"));
   }
 }

--- a/walkthroughs/week-5-tdd/intro/src/test/java/com/google/sps/GreeterTest.java
+++ b/walkthroughs/week-5-tdd/intro/src/test/java/com/google/sps/GreeterTest.java
@@ -30,4 +30,24 @@ public final class GreeterTest {
 
     Assert.assertEquals("Hello Ada", greeting);
   }
+
+  @Test
+  public void testGreetingTrimsWhitespace() {
+    Greeter greeter = new Greeter();
+
+    String greeting = greeter.greet("   Ada   ");
+
+    // Whitespace should be trimmed
+    Assert.assertEquals("Hello Ada", greeting);
+  }
+
+    @Test
+  public void testGreetingRemoveNonLetters() {
+    Greeter greeter = new Greeter();
+
+    String greeting = greeter.greet("   +A#d=|a ?@--;'%  ");
+
+    // Whitespace should be trimmed
+    Assert.assertEquals("Hello Ada", greeting);
+  }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import java.util.Comparator;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -24,6 +25,29 @@ import java.util.Set;
  * busy. Events are considered read-only.
  */
 public final class Event {
+
+   /**
+   * A comparator for sorting ranges by their start time in ascending order.
+   */
+  public static final Comparator<Event> ORDER_BY_START = 
+      new Comparator<Event>() {
+    @Override
+    public int compare(Event a, Event b) {
+      return TimeRange.ORDER_BY_START.compare(a.when, b.when);
+    }
+  };
+
+  /**
+   * A comparator for sorting ranges by their end time in ascending order.
+   */
+  public static final Comparator<Event> ORDER_BY_END = 
+      new Comparator<Event>() {
+    @Override
+    public int compare(Event a, Event b) {
+      return TimeRange.ORDER_BY_END.compare(a.when, b.when);
+    }
+  };
+
   private final String title;
   private final TimeRange when;
   private final Set<String> attendees = new HashSet<>();

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,9 +15,94 @@
 package com.google.sps;
 
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ArrayList;
 
+/**
+ * Given a list of events, find all time slots where no events are occurring.
+ */
 public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+    List<TimeRange> availableRanges = new ArrayList<>();
+
+    List<TimeRange> startSortedEvents = 
+        sortEvents(events, TimeRange.ORDER_BY_START);
+    List<TimeRange> endSortedEvents =
+        sortEvents(events, TimeRange.ORDER_BY_END);
+
+    // index of current position in startSortedEvents
+    int startIndex = 0;
+
+    //index of current position in endSortedEvents
+    int endIndex = 0;
+
+    //The maximum value startIndex and endIndex can have 
+    int maxIndex = events.size();
+
+    // keep track of how many attendees are busy before the current time
+    int busyAttendees = 0;
+
+    // keep track of when a possible available slot begins
+    int availableSlotStart = TimeRange.START_OF_DAY;
+
+    // temp variables to access event start and end times 
+    // from startSorted Events and endSortedEvents
+    int currStartTime;
+    int currEndTime;
+
+    //go through day by iterating through times of interest
+    // (when an event ends or starts)
+    while (endIndex < maxIndex) {
+      if (busyAttendees < 0) {
+        System.out.println("!!!!CANNOT HAVE NEGATIVE ATTENDEES!!!!!");
+        break;
+      }
+
+      currEndTime = endSortedEvents.get(endIndex).end();
+      currStartTime = startSortedEvents.get(
+          Math.min(startIndex, maxIndex-1)).start(); // startIndex could be equal to maxIndex
+
+      if (startIndex == maxIndex || currEndTime <= currStartTime) { // events can only end from this point on
+        availableSlotStart = currEndTime;
+        endIndex++;  
+        busyAttendees--;          
+      }
+      else { //an event starts now  
+        if (busyAttendees == 0) { 
+          availableRanges.add(TimeRange.fromStartEnd
+              (availableSlotStart, currStartTime, false));
+        }
+        startIndex ++;
+        busyAttendees++;
+      }
+    }
+
+    if (busyAttendees == 0) { //Add the time slot at the end of the day
+      availableRanges.add(TimeRange.fromStartEnd 
+        (availableSlotStart, TimeRange.END_OF_DAY, true));
+    }
+    else {
+      System.out.println("!!!!FINAL BUSY ATTENDEES ="+busyAttendees);
+    }
+
+    return availableRanges;
+  }
+
+  /**
+   * Sorts and returns the TimeRanges of the events given using the comparator
+   * @param events collection of events given to the query
+   * @param comparator comparator used to sort the event time ranges
+   * @return the sorted ArrayList of TimeRanges
+   */
+  private ArrayList<TimeRange> sortEvents (Collection<Event> events,Comparator<TimeRange> comparator) {
+    ArrayList<TimeRange> eventTimeRanges = new ArrayList<>();
+
+    for (Event event: events) {
+      eventTimeRanges.add(event.getWhen());
+    }
+
+    eventTimeRanges.sort(comparator);
+    return eventTimeRanges;
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -49,7 +49,7 @@ public final class FindMeetingQuery {
     int maxIndex = filteredEvents.size();
 
     // keep track of how many attendees are busy before the current time
-    List<String> busyAttendees = new ArrayList<>();
+    int busyAttendees = 0;
 
     // keep track of when a possible available slot begins
     int freeSlotStart = TimeRange.START_OF_DAY;
@@ -67,7 +67,7 @@ public final class FindMeetingQuery {
     //go through day by iterating through times of interest
     // (when an event ends or starts)
     while (endIndex < maxIndex) {
-      if (busyAttendees.size() < 0) {
+      if (busyAttendees < 0) {
         System.out.println("!!!!CANNOT HAVE NEGATIVE ATTENDEES!!!!!");
         break;
       }
@@ -81,19 +81,19 @@ public final class FindMeetingQuery {
 
       if (startIndex == maxIndex || endEventTime <= startEventTime) { // events can only end from this point on
         freeSlotStart = endEventTime;
-        busyAttendees.removeAll(endEvent.getAttendees());
+        busyAttendees--;
         endIndex++;         
       }
       else { //an event starts now  
-        if (busyAttendees.size() == 0) { 
+        if (busyAttendees == 0) { 
           addRange(availableRanges, minDuration, freeSlotStart, startEventTime, false);
         }
-        busyAttendees.addAll(startEvent.getAttendees());
+        busyAttendees++;
         startIndex ++;
       }
     }
 
-    if (busyAttendees.size() == 0) { //Add the time slot at the end of the day
+    if (busyAttendees == 0) { //Add the time slot at the end of the day
       addRange(availableRanges, minDuration, freeSlotStart, TimeRange.END_OF_DAY, true);
     }
     else {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -27,13 +27,13 @@ public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     List<TimeRange> availableRanges = new ArrayList<>();
 
-    Collection<Event> filteredEvents = 
+    List<Event> filteredEvents = 
         filterEventsByAttendees(request.getAttendees(), events);
 
-    List<TimeRange> startSortedEvents = 
-        sortEvents(filteredEvents, TimeRange.ORDER_BY_START);
-    List<TimeRange> endSortedEvents =
-        sortEvents(filteredEvents, TimeRange.ORDER_BY_END);
+    List<Event> startSortedEvents = 
+        sortEvents(filteredEvents, Event.ORDER_BY_START);
+    List<Event> endSortedEvents =
+        sortEvents(filteredEvents, Event.ORDER_BY_END);
 
     // min duration of the available time slot
     long minDuration = request.getDuration();
@@ -69,9 +69,9 @@ public final class FindMeetingQuery {
         break;
       }
 
-      currEndTime = endSortedEvents.get(endIndex).end();
-      currStartTime = startSortedEvents.get(
-          Math.min(startIndex, maxIndex-1)).start(); // startIndex could be equal to maxIndex
+      currEndTime = endSortedEvents.get(endIndex).getWhen().end();
+      currStartTime = startSortedEvents.get(Math.min(startIndex, maxIndex-1))
+          .getWhen().start(); // startIndex could be equal to maxIndex
 
       if (startIndex == maxIndex || currEndTime <= currStartTime) { // events can only end from this point on
         freeSlotStart = currEndTime;
@@ -98,21 +98,16 @@ public final class FindMeetingQuery {
   }
 
   /**
-   * Sorts and returns the TimeRanges of the events given using the
-   * comparator
+   * Returns a new collection object with the sorted events
    * @param events collection of events given to the query
    * @param comparator comparator used to sort the event time ranges
    * @return the sorted ArrayList of TimeRanges
    */
-  private ArrayList<TimeRange> sortEvents(Collection<Event> events,Comparator<TimeRange> comparator) {
-    ArrayList<TimeRange> eventTimeRanges = new ArrayList<>();
-
-    for (Event event: events) {
-      eventTimeRanges.add(event.getWhen());
-    }
-
-    eventTimeRanges.sort(comparator);
-    return eventTimeRanges;
+  private List<Event> sortEvents(List<Event> events, 
+      Comparator<Event> comparator) {
+    List<Event> sortedEvents = new ArrayList(events); 
+    sortedEvents.sort(comparator);
+    return sortedEvents;
   }
 
   /**
@@ -120,7 +115,7 @@ public final class FindMeetingQuery {
    * @param requestedAttendees people of interest
    * @param events events that need to be filtered
    */
-  private Collection<Event> filterEventsByAttendees
+  private List<Event> filterEventsByAttendees
       (Collection<String> requestedAttendees, Collection<Event> events) {
     List<Event> filteredEvents = new ArrayList<>();
     

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -26,10 +26,19 @@ import java.util.HashSet;
  */
 public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    List<TimeRange> availableRanges = new ArrayList<>();
+    //Time ranges that only consider mandatory attendees
+    List<TimeRange> freeMandatoryRanges = new ArrayList<>();
+
+    Set<String> mandatoryAttendees = 
+        new HashSet<>(request.getAttendees());
+
+    // Set that contains both mandatory and optional attendees
+    Set<String> allAttendees = 
+        new HashSet<>(request.getOptionalAttendees());
+    allAttendees.addAll(mandatoryAttendees);
 
     List<Event> filteredEvents = 
-        filterEventsByAttendees(request.getAttendees(), events);
+        filterEventsByAttendees(allAttendees, events);
 
     List<Event> startSortedEvents = 
         sortEvents(filteredEvents, Event.ORDER_BY_START);
@@ -86,7 +95,7 @@ public final class FindMeetingQuery {
       }
       else { //an event starts now  
         if (busyAttendees == 0) { 
-          addRange(availableRanges, minDuration, freeSlotStart, startEventTime, false);
+          addRange(freeMandatoryRanges, minDuration, freeSlotStart, startEventTime, false);
         }
         busyAttendees++;
         startIndex ++;
@@ -94,13 +103,13 @@ public final class FindMeetingQuery {
     }
 
     if (busyAttendees == 0) { //Add the time slot at the end of the day
-      addRange(availableRanges, minDuration, freeSlotStart, TimeRange.END_OF_DAY, true);
+      addRange(freeMandatoryRanges, minDuration, freeSlotStart, TimeRange.END_OF_DAY, true);
     }
     else {
       System.out.println("!!!!FINAL BUSY ATTENDEES ="+busyAttendees);
     }
 
-    return availableRanges;
+    return freeMandatoryRanges;
   }
 
   /**

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/TimeRange.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/TimeRange.java
@@ -173,7 +173,7 @@ public final class TimeRange {
    * included in the range will depend on {@code inclusive}. If {@code inclusive} is {@code true},
    * then @{code end} will be in the range.
    */
-  public static TimeRange fromStartEnd(int start, int end, boolean inclusive) {
+  public static TimeRange fromStartEnd(int start, int end, boolean inclusive) { //TODO: throw exception if end is before start
     return inclusive ? new TimeRange(start, end - start + 1) : new TimeRange(start, end - start);
   }
 
@@ -181,6 +181,7 @@ public final class TimeRange {
    * Create a {@code TimeRange} starting at {@code start} with a duration equal to {@code duration}.
    */
   public static TimeRange fromStartDuration(int start, int duration) {
+    //TODO: throw exception if duration is negative;
     return new TimeRange(start, duration);
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -38,6 +38,7 @@ public final class FindMeetingQueryTest {
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
+  private static final int TIME_0845AM = TimeRange.getTimeInMinutes(8, 45);
   private static final int TIME_0830AM = TimeRange.getTimeInMinutes(8, 30);
   private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
   private static final int TIME_0915AM = TimeRange.getTimeInMinutes(9, 15);  
@@ -290,7 +291,7 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)),
         new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, 
             TIME_0845AM, false),
-            Arrays.asList(PERSON_B)),);    
+            Arrays.asList(PERSON_B)));    
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_B);

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -178,7 +178,7 @@ public final class FindMeetingQueryTest {
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
-  }
+  } 
 
   @Test
   public void overlappingEvents() {
@@ -402,5 +402,5 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> expected = Arrays.asList();
 
     Assert.assertEquals(expected, actual);
-  }
+  } 
 }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,20 +34,29 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
   private static final int TIME_0830AM = TimeRange.getTimeInMinutes(8, 30);
   private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
+  private static final int TIME_0915AM = TimeRange.getTimeInMinutes(9, 15);  
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
+  private static final int TIME_1200PM = TimeRange.getTimeInMinutes(12, 00);
+  private static final int TIME_0200PM = TimeRange.getTimeInMinutes(14, 00);
+  private static final int TIME_0300PM = TimeRange.getTimeInMinutes(15, 00);
+  private static final int TIME_0315PM = TimeRange.getTimeInMinutes(15, 15);
+  private static final int TIME_0500PM = TimeRange.getTimeInMinutes(17, 00);
 
+  private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
   private static final int DURATION_1_HOUR = 60;
   private static final int DURATION_2_HOUR = 120;
+  private static final int DURATION_WHOLE_DAY = 24*60;
 
   private FindMeetingQuery query;
 
@@ -116,6 +125,55 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeIsNotConsidered() {
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TimeRange.START_OF_DAY,
+            DURATION_WHOLE_DAY),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), 
+            DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeIsConsidered() {
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM,
+            DURATION_30_MINUTES),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), 
+            DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -224,6 +282,27 @@ public final class FindMeetingQueryTest {
   }
 
   @Test
+  public void optionalNotEnoughRoom() {
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, 
+            TIME_0845AM, false),
+            Arrays.asList(PERSON_B)),);    
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
   public void ignoresPeopleNotAttending() {
     // Add an event, but make the only attendee someone different from the person looking to book
     // a meeting. This event should not affect the booking.
@@ -270,5 +349,57 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
-}
 
+  @Test
+  public void allOptionalAttendees() {
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, 
+            TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, 
+            DURATION_15_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_1200PM,
+            DURATION_2_HOUR),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 4", TimeRange.fromStartDuration(TIME_0300PM,
+            DURATION_15_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 5", TimeRange.fromStartEnd(TIME_0500PM,
+            TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)));    
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_15_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList(
+          TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+          TimeRange.fromStartEnd(TIME_0915AM, TIME_1200PM, false),
+          TimeRange.fromStartEnd(TIME_0200PM, TIME_0300PM, false),
+          TimeRange.fromStartEnd(TIME_0315PM, TIME_0500PM, false));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void allOptionalAttendeesNoTime() {
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, 
+            TIME_1200PM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_1200PM, 
+            TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_B)));    
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_15_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+}


### PR DESCRIPTION
Implement FindMeetingQuery() such that, given a list of events and a meeting request, it returns all possible meeting times.

The meeting requests are defined to have **mandatory attendees (MAs)**, **optional attendees (OAs)** as well as a minimum amount of time required for the meeting. FindMeetingQuery() is defined such that, when given a list of events occurring that day, it will determine all the possible **time ranges (TRs)** that are at least as long as the duration of the meeting and when all attendees are available. If no such times are found, it returns all the times when only the mandatory attendees are available.

Before looking for time ranges, FindMeetingQuery() refines the event list by filtering out all events that do not include anyone requested for the meeting and returns a list of new events that are identical to the filtered events except that all attendees that are not relevant for this meeting are not included. Once this is done, using new Comparators for Events (which use the pre-defined comparators for TimeRanges), FindMeetingQuery() then copies the filtered list of events into two sorted arrays, one by the start times of the events, and one by the end times of the events.

From this point on, the function finds all the possible meeting times by iterating through the **times-of-interest (TOIs)** of the day (this includes when an event starts or ends) in order of occurrence while updating a running count of the number of busy MAs and the number of busy OAs based on who joined or left each event. 

Before an event involving MAs starts, if there are currently no busy MAs, the time range from the previous TOI (that involves MAs) to this TOI is added to the list of TRs dedicated just to MAs (when adding a TR, its length is taken into account). If the event only involved OAs, and all attendees are available, the time range from the previous TOI that involves **any** attendees to this TOI is added to the list of TRs dedicated to all attendees. 

Similarly, when an event that involves MAs ends, this TOI is stored temporarily as a possible time when a mandatory or optional meeting availability could open up, but this isn't checked until the next TOI so, once done iterating through the TOIs, the time ranges from the end of the last MA-TOI and OA-TOI to the end of the day need to be added to their respective lists as well.

After this, if the optional TRs list is not empty, it is returned. And if not, the mandatory TR list is returned instead.

If, at the very beginning, there are no mandatory attendees in the meeting request, all the optional attendees are treated as mandatory attendees.

TODO: implement optional challenge of returning times when the most OAs are available if no times for everyone are found.